### PR TITLE
Remove illegal characters from package name

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Push Notifications API Server",
+  "name": "push-notifications-api-server",
   "version": "1.2.2",
   "description": "Server for handling push notifications",
   "scripts": {


### PR DESCRIPTION
From the npm Docs https://docs.npmjs.com/cli/v11/configuring-npm/package-json: 

> - New packages must not have uppercase letters in the name.
> - The name ends up being part of a URL, an argument on the command line, and a folder name. Therefore, the name can't contain any non-URL-safe characters.

While this does not seem like a big deal for a project that is not planned as a published npm package there are some unfortunate side effects. For example if you choose [Yarn](https://classic.yarnpkg.com) as your package manager, it does not install the packages with following error message:

```error package.json: Name contains illegal characters```